### PR TITLE
Add support for azurerm 2.x and azurecaf providers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+    "name": "Azure CAF rover",
+ 
+    // Update the 'dockerComposeFile' list if you have more compose files or use different names.
+    "dockerComposeFile": "docker-compose.yml",
+ 
+    // The 'service' property is the name of the service for the container that VS Code should
+    // use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+    "service": "rover",
+ 
+    // The optional 'workspaceFolder' property is the path VS Code should open by default when
+    // connected. This is typically a volume mount in .devcontainer/docker-compose.yml
+    "workspaceFolder": "/tf/caf",
+ 
+    // Use 'settings' to set *default* container specific settings.json values on container create. 
+    // You can edit these settings after create using File > Preferences > Settings > Remote.
+    "settings": { 
+        // If you are using an Alpine-based image, change this to /bin/ash
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
+ 
+    // Uncomment the next line if you want start specific services in your Docker Compose config.
+    // "runServices": [],
+ 
+    // Uncomment this like if you want to keep your containers running after VS Code shuts down.
+    // "shutdownAction": "none",
+ 
+    // Uncomment the next line to run commands after the container is created.
+    "postCreateCommand": "cp -R /tmp/.ssh-localhost/* ~/.ssh && chmod 700 ~/.ssh && chmod 600 ~/.ssh/*",
+ 
+    // Add the IDs of extensions you want installed when the container is created in the array below.
+    "extensions": [
+        "4ops.terraform",
+        "mutantdino.resourcemonitor"
+    ]
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+ 
+  version: '3.7'
+  services:
+    rover:
+      image: aztfmod/roverdev:2003.200951
+    
+      labels:
+        - "caf=Azure CAF"
+   
+      volumes:
+        # This is where VS Code should expect to find your project's source code
+        # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
+        - ..:/tf/caf
+        - volume-caf-vscode:/home/vscode
+        - ~/.ssh:/tmp/.ssh-localhost:ro
+        - /var/run/docker.sock:/var/run/docker.sock 
+   
+      # Overrides default command so things don't shut down after the process ends.
+      command: /bin/sh -c "while sleep 1000; do :; done" 
+   
+  volumes:
+    volume-caf-vscode:
+      labels:
+        - "caf=Azure CAF"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,7 @@
   version: '3.7'
   services:
     rover:
-      image: aztfmod/roverdev:2003.200951
+      image: aztfmod/rover:2003.2503
     
       labels:
         - "caf=Azure CAF"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## v2.0 (March 2020)
+
+FEATURES: 
+* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#4](https://github.com/aztfmod/terraform-azurerm-caf-log-analytics/issues/4))
+
+IMPROVEMENTS:
+
+BUGS:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Build status](https://dev.azure.com/azure-terraform/Blueprints/_apis/build/status/modules/log_analytics)](https://dev.azure.com/azure-terraform/Blueprints/_build/latest?definitionId=3)
+[![Gitter](https://badges.gitter.im/aztfmod/community.svg)](https://gitter.im/aztfmod/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 # Deploys Azure Monitor Log Analytics 
 Creates the log analytics and monitoring solutions. 
-
 
 Reference the module to a specific version (recommended):
 ```hcl
@@ -19,83 +19,24 @@ module "log_analytics" {
 }
 ```
 
-# Parameters
+## Inputs 
 
-## name
-(Required) Log Analytics workspace name
-```hcl
-variable "name" {
-  description = "Log Analytics workspace name"
-}
-```
-Example
-```hcl
-name = "myloganalytics"
-```
+| Name | Type | Default | Description |
+| -- | -- | -- | -- |
+| resource_group_name | string | None | (Required) Name of the resource group where to create the resource. Changing this forces a new resource to be created. |
+| name | string | None | (Required) Name for the objects created (before naming convention applied.) |
+| location | string | None | (Required) Specifies the Azure location to deploy the resource. Changing this forces a new resource to be created.  |
+| tags | map | None | (Required) Map of tags for the deployment.  |
+| solution_plan_map | map | None | (Required) Map structure containing the list of solutions to be enabled. (see details of the structure in the Parameters section below) |
+| convention | string | None | (Required) Naming convention to be used (check at the naming convention module for possible values).  |
+| prefix | string | None | (Optional) Prefix to be used. |
+| postfix | string | None | (Optional) Postfix to be used. |
+| max_length | string | None | (Optional) maximum length to the name of the resource. |
 
-## resource_group_name
-(Required) (Required) Name of the resource group to deploy the operations log.
-```hcl
-variable "resource_group_name" {
-  description = "(Required) Name of the resource group to deploy the operations log."
-}
 
-```
-Example
-```hcl
-resource_group_name = "operations-rg"
-```
+## Parameters
 
-## location
-(Required) Define the region where the resource groups will be created
-```hcl
-variable "location" {
-  description = "(Required) Define the region where the resource groups will be created"
-  type        = string
-}
-```
-Example
-```
-    location    = "southeastasia"
-```
-
-## prefix
-(Optional) You can use a prefix to add to the list of resource groups you want to create
-```hcl
-variable "prefix" {
-    description = "(Optional) You can use a prefix to add to the list of resource groups you want to create"
-}
-```
-Example
-```hcl
-locals {
-    prefix = "${random_string.prefix.result}-"
-}
-
-resource "random_string" "prefix" {
-    length  = 4
-    upper   = false
-    special = false
-}
-```
-
-## tags
-(Required) Map of tags for the deployment
-```hcl
-variable "tags" {
-  description = "(Required) map of tags for the deployment"
-}
-```
-Example
-```hcl
-tags = {
-    environment     = "DEV"
-    owner           = "Arnaud"
-    deploymentType  = "Terraform"
-  }
-```
-
-## solution_plan_map
+### solution_plan_map
 (Required) Map of tags for the deployment
 ```hcl
 variable "solution_plan_map" {
@@ -129,20 +70,9 @@ solution_plan_map = {
 }
 
 ```
-## convention
-(Required) Naming convention to be used.
-```hcl
-variable "convention" {
-  description = "(Required) Naming convention used"
-}
-```
-Example
-```hcl
-convention = "cafclassic"
-```
 
 
-# Outputs
+## Outputs
 
 | Name | Type | Description | 
 | -- | -- | -- | 

--- a/examples/log_analytics/locals.tf
+++ b/examples/log_analytics/locals.tf
@@ -1,5 +1,5 @@
 locals {
-    convention = "cafrandom"
+    convention = "cafclassic"
     name = "caftest"
     location = "southeastasia"
     prefix = "test"

--- a/examples/log_analytics/locals.tf
+++ b/examples/log_analytics/locals.tf
@@ -1,5 +1,5 @@
 locals {
-    convention = "random"
+    convention = "cafrandom"
     name = "caftest"
     location = "southeastasia"
     prefix = "test"

--- a/examples/log_analytics/log_analytics.tf
+++ b/examples/log_analytics/log_analytics.tf
@@ -1,10 +1,7 @@
-module "rg_test" {
-  source  = "aztfmod/caf-resource-group/azurerm"
-  version = "0.1.1"
-  
-    prefix          = local.prefix
-    resource_groups = local.resource_groups
-    tags            = local.tags
+resource "azurerm_resource_group" "rg_test" {
+  name     = local.resource_groups.test.name
+  location = local.resource_groups.test.location
+  tags     = local.tags
 }
 
 module "la_test" {
@@ -14,7 +11,7 @@ module "la_test" {
     location            = local.location
     name                = local.name
     solution_plan_map   = local.solution_plan_map 
-    prefix              = local.prefix
-    resource_group_name = module.rg_test.names.test
+    # prefix              = local.prefix
+    resource_group_name = azurerm_resource_group.rg_test.name
     tags                = local.tags
 }

--- a/examples/log_analytics/main.tf
+++ b/examples/log_analytics/main.tf
@@ -1,0 +1,4 @@
+provider "azurerm" {
+  version = "~>2.2.0"
+  features {}
+}

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,7 @@
+provider "azurecaf" {
+  
+}
+
 locals {
   module_tag          = {
     "module" = basename(abspath(path.module))

--- a/module.tf
+++ b/module.tf
@@ -1,14 +1,12 @@
-module "caf_name_la" {
-  source  = "aztfmod/caf-naming/azurerm"
-  version = "~> 0.1.0"
-    
+resource "azurecaf_naming_convention" "caf_name_la" {  
   name    = var.name
-  type    = "la"
+  prefix  = var.prefix != "" ? var.prefix : null
+  resource_type    = "la"
   convention  = var.convention
 }
 
 resource "azurerm_log_analytics_workspace" "log_analytics" {
-  name                = module.caf_name_la.la
+  name                = azurecaf_naming_convention.caf_name_la.result
   location            = var.location
   resource_group_name = var.resource_group_name
   sku                 = "PerGB2018"

--- a/module.tf
+++ b/module.tf
@@ -1,7 +1,9 @@
 resource "azurecaf_naming_convention" "caf_name_la" {  
   name    = var.name
   prefix  = var.prefix != "" ? var.prefix : null
-  resource_type    = "la"
+  resource_type    = "azurerm_log_analytics_workspace"
+  postfix       = var.postfix != "" ? var.postfix : null
+  max_length    = var.max_length != "" ? var.max_length : null
   convention  = var.convention
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,17 +6,12 @@ variable "location" {
   description = "(Required) Location of the resources"
 }
 
-variable "prefix" {
-  description = "(Optional) Prefix to add to resources"
-  default = ""
-}
-
 variable "name" {
   description = "(Required) Log Analytics workspace name"
 }
 
 variable "solution_plan_map" {
-  description = "(Optional) Map structure containing the list of solutions to be enabled."
+  description = "(Required) Map structure containing the list of solutions to be enabled."
   type = map(any)
 }
 
@@ -26,4 +21,22 @@ variable "tags" {
 
 variable "convention" {
   description = "(Required) Naming convention method to use"  
+}
+
+variable "prefix" {
+  description = "(Optional) You can use a prefix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "postfix" {
+  description = "(Optional) You can use a postfix to the name of the resource"
+  type        = string
+  default = ""
+}
+
+variable "max_length" {
+  description = "(Optional) You can speficy a maximum length to the name of the resource"
+  type        = string
+  default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,7 @@ variable "location" {
 
 variable "prefix" {
   description = "(Optional) Prefix to add to resources"
+  default = ""
 }
 
 variable "name" {


### PR DESCRIPTION
## v2.0 (March 2020)

FEATURES: 
* **new feature:**  Add support for azurerm 2.x and azurecaf providers ([#4](https://github.com/aztfmod/terraform-azurerm-caf-log-analytics/issues/4))
