### PR TITLE
Fix for #6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v2.0.1 (March 2020)
+
+BUGS: 
+* **bug fix:**  error removing a the caf diagnostics logging module 2.0.0 ([#6](https://github.com/aztfmod/terraform-azurerm-caf-caf-log-analytics/issues/6))
+
+
 ## v2.0 (March 2020)
 
 FEATURES: 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
-provider "azurecaf" {
+# provider "azurecaf" {
   
-}
+# }
 
 locals {
   module_tag          = {


### PR DESCRIPTION
## v2.0.1 (March 2020)

BUGS: 
* **bug fix:**  error removing a the caf diagnostics logging module 2.0.0 ([#6](https://github.com/aztfmod/terraform-azurerm-caf-caf-log-analytics/issues/6))
